### PR TITLE
Support oncoanalyser v2.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,13 +16,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build image
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
         run: |
           if [[ "${{ matrix.build_name }}" == "base" ]]; then
             docker_tag=bolt:${GITHUB_REF_NAME#v};
@@ -31,4 +43,12 @@ jobs:
             docker_tag=bolt:${GITHUB_REF_NAME#v}-${{ matrix.build_name }};
             dockerfile_fn=Dockerfile.${{ matrix.build_name }};
           fi;
-          docker build --push -f docker/${dockerfile_fn} -t ghcr.io/${{ github.repository_owner }}/${docker_tag} .;
+
+          # Build and push to docker.io and GHCR umccr registries
+          docker build \
+            --platform linux/amd64 \
+            -f docker/${dockerfile_fn} \
+            -t ghcr.io/umccr/${docker_tag} \
+            -t docker.io/umccr/${docker_tag} \
+            --push \
+            .;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 - [3](https://github.com/scwatts/bolt/pull/3) - Improve PCGR / CPSR argument handling
 
-- [6](https://github.com/umccr/bolt/pull/6) - Change oncoanalyser v2 uptade, with switch sv caller from GRIPSS to eSVee
+- [6](https://github.com/umccr/bolt/pull/6) - Change oncoanalyser v2.0.0 uptade, with switch sv caller from GRIPSS to eSVee

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## dev
 
 - [3](https://github.com/scwatts/bolt/pull/3) - Improve PCGR / CPSR argument handling
+
+- [6](https://github.com/umccr/bolt/pull/6) - Change oncoanalyser v2 uptade, with switch sv caller from GRIPSS to eSVee

--- a/bolt/workflows/other/purple_baf_plot.py
+++ b/bolt/workflows/other/purple_baf_plot.py
@@ -44,6 +44,10 @@ def entry(ctx, **kwargs):
             cp ${{src_fp}} {output_dir}/;
         done;
 
+        # Purple 4.1 introduced bezier radius in link file that overrides circos config. Removed for plot readability.
+        # e.g: color=black,bezier_radius=0.189r
+        sed -i 's/,bezier_radius=[0-9.]*r//g' {output_dir}/{kwargs["tumor_name"]}.link.circos;
+
         cp {circos_gaps_fp} {output_dir}/gaps.txt;
 
         circos \

--- a/bolt/workflows/sv_somatic/annotate.py
+++ b/bolt/workflows/sv_somatic/annotate.py
@@ -76,7 +76,7 @@ def compile_variants(sv_fp, cnv_fp, tumor_name, ref_fp, output_dir):
 
     # SVs
     for record in sv_fh:
-        record.INFO['SOURCE'] = 'sv_gridss'
+        record.INFO['SOURCE'] = 'sv_esvee'
         output_fh.write_record(record)
 
     # CNVs

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -62,11 +62,9 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         'chrom',
         'start',
         'svtype',
-        'SR_alt',
-        'PR_alt',
-        'SR_asm_alt',
-        'PR_asm_alt',
-        'IC_alt',
+        'VF_alt',
+        'SB_alt',
+        'SF_alt',
         'SR_ref',
         'PR_ref',
         'QUAL',
@@ -98,13 +96,9 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         # Select most appropriate read support categories
         # NOTE(SW): BNDs can also report breakend support, ignoring in preference to breakpoint support
         eventtype = record.INFO.get('SVTYPE', '')
-        if eventtype == 'SGL':
-            read_support_fields = ['BSC', 'BUM', 'BASSR', 'BASRP']
-        else:
-            read_support_fields = ['SR', 'RP', 'ASSR', 'ASRP']
-        assert len(read_support_fields) == 4
-        read_support_fields.extend(('IC', 'REF', 'REFPAIR'))
-        read_support_data = [parse_read_support_field(record, e) for e in read_support_fields]
+
+        read_support_fields = ['VF', 'SB', 'SF', 'REF', 'REFPAIR']
+        read_support_data = [parse_read_support_field(record, tag) for tag in read_support_fields]
 
         data = (
             record.CHROM.replace('chr', ''),

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -191,10 +191,18 @@ def parse_info_field(record, field_name):
 
 
 def parse_read_support_field(record, field_name):
-    if (data := record.format(field_name)):
+    """
+    Safely pull FORMAT/<field_name>. Returns first sample’s first value,
+    or '' if the tag is missing or empty.
+    """
+    try:
+        data = record.format(field_name)
+    except KeyError:
+        # FORMAT/<field_name> not in header → skip
+        return ''
+    if data and len(data) > 0:
         return data[0][0]
-    else:
-        return str()
+    return ''
 
 
 def split_records(input_fp, tumor_name, output_dir, variant_type):

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -97,7 +97,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
 
         # Select most appropriate read support categories
         # NOTE(SW): BNDs can also report breakend support, ignoring in preference to breakpoint support
-        eventtype = record.INFO.get('EVENTTYPE', '')
+        eventtype = record.INFO.get('SVTYPE', '')
         if eventtype == 'SGL':
             read_support_fields = ['BSC', 'BUM', 'BASSR', 'BASRP']
         else:

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -56,7 +56,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
 
     # NOTE(SW): the cancer report previously used Manta FORMAT/SR and FORMAT/PR as a diagnostic for
     # SV quality. However, eSVee handles read counts slightly different and has many measures of
-    # various read support/non-support. For now I am using FORMAT/SR and FORMAT/RP.
+    # various read support/non-support. For now I am using FORMAT/DF and FORMAT/.
 
     header = (
         'chrom',
@@ -68,6 +68,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         'SR_ref',
         'PR_ref',
         'QUAL',
+        'filter',
         'tier',
         'annotation',
         'AF_PURPLE',
@@ -106,6 +107,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
             eventtype,
             *read_support_data,
             record.QUAL,
+            record.FILTER,
             record.INFO.get('SV_TOP_TIER', 4),
             record.INFO['SIMPLE_ANN'],
             parse_info_field(record, 'PURPLE_AF'),

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -1,5 +1,4 @@
 import pathlib
-import sys
 
 import click
 import cyvcf2

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 
 import click
 import cyvcf2
@@ -186,14 +187,14 @@ def parse_info_field(record, field_name):
 
 def parse_read_support_field(record, field_name):
     """
-    Safely pull FORMAT/<field_name>. Returns first sample’s first value,
-    or '' if the tag is missing or empty.
+    Pull FORMAT/<field_name>. First value,
+    or '' if the tag is empty.
     """
     try:
         data = record.format(field_name)
     except KeyError:
-        # FORMAT/<field_name> not in header → skip
-        return ''
+        print(f"Error: FORMAT field '{field_name}' not found in VCF for record: {record.CHROM}:{record.POS}", file=sys.stderr)
+        sys.exit(1)
     if data and len(data) > 0:
         return data[0][0]
     return ''

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -56,7 +56,7 @@ def entry(ctx, **kwargs):
 def create_sv_tsv(input_fp, tumor_name, output_dir):
 
     # NOTE(SW): the cancer report previously used Manta FORMAT/SR and FORMAT/PR as a diagnostic for
-    # SV quality. However, GRIDSS handles read counts slightly different and has many measures of
+    # SV quality. However, eSVee handles read counts slightly different and has many measures of
     # various read support/non-support. For now I am using FORMAT/SR and FORMAT/RP.
 
     header = (
@@ -202,7 +202,7 @@ def parse_read_support_field(record, field_name):
 
 def split_records(input_fp, tumor_name, output_dir, variant_type):
     if variant_type == 'sv':
-        source = 'sv_gridss'
+        source = 'sv_esvee'
     elif variant_type == 'cnv':
         source = 'cnv_purple'
     else:

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -64,7 +64,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         'start',
         'svtype',
         'VF_alt',
-        'SB_alt',
+        'DF_alt',
         'SF_alt',
         'SR_ref',
         'PR_ref',
@@ -98,7 +98,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         # NOTE(SW): BNDs can also report breakend support, ignoring in preference to breakpoint support
         eventtype = record.INFO.get('SVTYPE', '')
 
-        read_support_fields = ['VF', 'SB', 'SF', 'REF', 'REFPAIR']
+        read_support_fields = ['VF', 'DF', 'SF', 'REF', 'REFPAIR']
         read_support_data = [parse_read_support_field(record, tag) for tag in read_support_fields]
 
         data = (
@@ -193,8 +193,8 @@ def parse_read_support_field(record, field_name):
     try:
         data = record.format(field_name)
     except KeyError:
-        print(f"Error: FORMAT field '{field_name}' not found in VCF for record: {record.CHROM}:{record.POS}", file=sys.stderr)
-        sys.exit(1)
+        error_message = f"Error: FORMAT field '{field_name}' not found in VCF for record: {record.CHROM}:{record.POS}"
+        raise ValueError(error_message)
     if data and len(data) > 0:
         return data[0][0]
     return ''

--- a/bolt/workflows/sv_somatic/prioritise.py
+++ b/bolt/workflows/sv_somatic/prioritise.py
@@ -56,7 +56,7 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
 
     # NOTE(SW): the cancer report previously used Manta FORMAT/SR and FORMAT/PR as a diagnostic for
     # SV quality. However, eSVee handles read counts slightly different and has many measures of
-    # various read support/non-support. For now I am using FORMAT/DF and FORMAT/.
+    # various read support/non-support. For now I am using FORMAT/DF and FORMAT/SF.
 
     header = (
         'chrom',
@@ -65,8 +65,8 @@ def create_sv_tsv(input_fp, tumor_name, output_dir):
         'VF_alt',
         'DF_alt',
         'SF_alt',
-        'SR_ref',
-        'PR_ref',
+        'REF_frag',
+        'REF_pair',
         'QUAL',
         'filter',
         'tier',


### PR DESCRIPTION
# Updates to support onconanalyser v2.0.0 input

The main change is structural variant (SV) annotation and prioritization, to accomodate the switch from `GRIDSS` to `eSVee` as the primary SV caller. 

### Transition to `eSVee` for SV annotation and prioritization:

* Adjusted the logic for selecting read support fields to use `eSVee` tags (`VF`, `DF`, `SF`) instead of `GRIDSS` tags (`SR`, `RP`, `ASSR`, `ASRP`, `IC`) in `prioritise.py`.


### Add filter tags in tsv for gpgr